### PR TITLE
chore(FOM-130): stop deploying this repo, switch remaining auth to OIDC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,9 @@ jobs:
   Deploy-infra:
     name: 'Deploy Infra'
     needs: [Pre-check, Build-Rust-Lambdas]
+    permissions:
+      id-token: write
+      contents: read
     uses: fomiller/gh-actions/.github/workflows/terragrunt.yaml@main
     with:
       environment: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref) && 'prod' || 'dev' }}
@@ -53,6 +56,7 @@ jobs:
       doppler-project: dungeons-and-llamas
       download-artifacts: true
       artifacts_dir: infra/modules/aws/lambda/bin
+      use-oidc: true
     secrets: inherit
      
     

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,18 +2,10 @@
 
 name: 'Terragrunt Deploy'
   
+# Manual only. This repo isn't deployed anymore and its AWS infra is being torn
+# down (FOM-132), so a push must not apply terraform.
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - "develop"
-      - "feature/*"
-    paths:
-      - '.github/**'
-      - 'infra/**'
-      - 'src/**'
-      - 'just/**'
-      - 'justfile'
    
 jobs:
   Pre-check:


### PR DESCRIPTION
Turns off the automatic deploy. The workflow is `workflow_dispatch` only now, so a push doesn't apply terraform.

Also carries the [FOM-130](https://linear.app/fomiller/issue/FOM-130/move-ci-to-github-oidc-federated-roles) OIDC change, so if it ever is run by hand it uses the federated role instead of static keys. That matters because the IAM users and their keys are being deleted.

Teardown of what's left in AWS is [FOM-132](https://linear.app/fomiller/issue/FOM-132/tear-down-dungeons-and-llamas-aws-infra).